### PR TITLE
feat: improve text visibility across app

### DIFF
--- a/frontend/src/app/auth/login/page.tsx
+++ b/frontend/src/app/auth/login/page.tsx
@@ -45,14 +45,14 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
-        <h2 className="text-2xl font-bold text-center text-gray-900">Login</h2>
+    <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
+      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md dark:bg-gray-800">
+        <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100">Login</h2>
         <form className="space-y-6" onSubmit={handleLogin}>
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
               Email address
             </label>
@@ -65,15 +65,15 @@ export default function LoginPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
+                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-500"
+                />
             </div>
           </div>
 
           <div>
             <label
               htmlFor="password"
-              className="block text-sm font-medium text-gray-700"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
             >
               Password
             </label>
@@ -86,8 +86,8 @@ export default function LoginPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
+                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-500"
+                />
             </div>
           </div>
 
@@ -102,10 +102,10 @@ export default function LoginPage() {
         </form>
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-300" />
+            <div className="w-full border-t border-gray-300 dark:border-gray-600" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">
+            <span className="px-2 bg-white text-gray-500 dark:bg-gray-800 dark:text-gray-400">
               Or continue with
             </span>
           </div>
@@ -114,7 +114,7 @@ export default function LoginPage() {
           <div>
             <button
               onClick={() => handleOAuthLogin(OAuthProvider.Google)}
-              className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+              className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600"
             >
               <span className="sr-only">Sign in with Google</span>
               <svg
@@ -134,7 +134,7 @@ export default function LoginPage() {
           <div>
             <button
               onClick={() => handleOAuthLogin(OAuthProvider.Facebook)}
-              className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50"
+              className="inline-flex justify-center w-full px-4 py-2 text-sm font-medium text-gray-500 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-600"
             >
               <span className="sr-only">Sign in with Facebook</span>
               <svg

--- a/frontend/src/app/auth/signup/page.tsx
+++ b/frontend/src/app/auth/signup/page.tsx
@@ -29,20 +29,20 @@ export default function SignupPage() {
     }
   };
 
-  return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
-        <h2 className="text-2xl font-bold text-center text-gray-900">
-          Create an account
-        </h2>
-        <form className="space-y-6" onSubmit={handleSignup}>
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
+        <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md dark:bg-gray-800">
+          <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100">
+            Create an account
+          </h2>
+          <form className="space-y-6" onSubmit={handleSignup}>
           <div>
             <label
-              htmlFor="name"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Name
-            </label>
+                htmlFor="name"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Name
+              </label>
             <div className="mt-1">
               <input
                 id="name"
@@ -52,17 +52,17 @@ export default function SignupPage() {
                 required
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
+                  className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-500"
+                  />
             </div>
           </div>
           <div>
             <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Email address
-            </label>
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Email address
+              </label>
             <div className="mt-1">
               <input
                 id="email"
@@ -72,18 +72,18 @@ export default function SignupPage() {
                 required
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
+                  className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-500"
+                  />
             </div>
           </div>
 
           <div>
             <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Password
-            </label>
+                htmlFor="password"
+                className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Password
+              </label>
             <div className="mt-1">
               <input
                 id="password"
@@ -93,8 +93,8 @@ export default function SignupPage() {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
-              />
+                  className="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-500"
+                  />
             </div>
           </div>
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -49,10 +49,10 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-4xl p-8 space-y-6 bg-white rounded-lg shadow-md">
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
+      <div className="w-full max-w-4xl p-8 space-y-6 bg-white rounded-lg shadow-md dark:bg-gray-800">
         <div className="flex items-center justify-between">
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             Welcome, {user.name}!
           </h2>
           <button
@@ -63,29 +63,29 @@ export default function Home() {
           </button>
         </div>
         <div className="mt-8">
-          <h3 className="text-lg font-medium leading-6 text-gray-900">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
             Training Modules
           </h3>
           <div className="grid grid-cols-1 gap-6 mt-6 sm:grid-cols-2 lg:grid-cols-3">
             {/* Placeholder for training modules */}
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <h4 className="text-lg font-bold">A320 Walk Around Inspection</h4>
-              <p className="mt-2 text-sm text-gray-600">
+            <div className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700">
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">A320 Walk Around Inspection</h4>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                 An interactive training module for the A320 walk around
                 inspection.
               </p>
             </div>
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <h4 className="text-lg font-bold">A320 Aircraft Marshalling</h4>
-              <p className="mt-2 text-sm text-gray-600">
+            <div className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700">
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">A320 Aircraft Marshalling</h4>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                 An interactive training module for A320 aircraft marshalling.
               </p>
             </div>
-            <div className="p-6 bg-gray-50 rounded-lg">
-              <h4 className="text-lg font-bold">
+            <div className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700">
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">
                 CFM56-5B Engine General Overview
               </h4>
-              <p className="mt-2 text-sm text-gray-600">
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                 An interactive training module for the CFM56-5B engine.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- add dark mode styles to home screen for improved readability
- enhance login and signup pages with dark theme friendly labels and inputs

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c8b80493c8320a56444f58b890137