### PR TITLE
Integrate Unity module and link from training modules

### DIFF
--- a/frontend/public/unity/index.html
+++ b/frontend/public/unity/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Unity WebGL Build</title>
+  </head>
+  <body>
+    <p>Unity WebGL build will be placed here. Replace this file with the actual build output.</p>
+  </body>
+</html>

--- a/frontend/src/app/modules/a320-walk-around/page.tsx
+++ b/frontend/src/app/modules/a320-walk-around/page.tsx
@@ -1,0 +1,12 @@
+export default function A320WalkAround() {
+  return (
+    <div className="w-full h-screen">
+      <iframe
+        src="/unity/index.html"
+        title="A320 Walk Around"
+        className="w-full h-full border-0"
+        allow="fullscreen"
+      />
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { account } from '@/lib/appwrite';
 import { useRouter } from 'next/navigation';
 import { AppwriteException, Models } from 'appwrite';
 import toast from 'react-hot-toast';
+import Link from 'next/link';
 
 export default function Home() {
   const [user, setUser] = useState<Models.User<Models.Preferences> | null>(
@@ -68,13 +69,18 @@ export default function Home() {
           </h3>
           <div className="grid grid-cols-1 gap-6 mt-6 sm:grid-cols-2 lg:grid-cols-3">
             {/* Placeholder for training modules */}
-            <div className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700">
-              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">A320 Walk Around Inspection</h4>
+            <Link
+              href="/modules/a320-walk-around"
+              className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700 block"
+            >
+              <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">
+                A320 Walk Around Inspection
+              </h4>
               <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">
                 An interactive training module for the A320 walk around
                 inspection.
               </p>
-            </div>
+            </Link>
             <div className="p-6 bg-gray-50 rounded-lg dark:bg-gray-700">
               <h4 className="text-lg font-bold text-gray-900 dark:text-gray-100">A320 Aircraft Marshalling</h4>
               <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
## Summary
- Link A320 walk around module to a new page
- Display Unity WebGL build via iframe placeholder

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c913b8a5c83209da84e6f03a9529c